### PR TITLE
feat: restore algolia search assets

### DIFF
--- a/assets/algolia_analytics.js
+++ b/assets/algolia_analytics.js
@@ -1,0 +1,2 @@
+window.algoliaShopify = window.algoliaShopify || {};
+// Placeholder for algolia_analytics.js

--- a/assets/algolia_autocomplete.js
+++ b/assets/algolia_autocomplete.js
@@ -1,0 +1,2 @@
+window.algoliaShopify = window.algoliaShopify || {};
+// Placeholder for algolia_autocomplete.js

--- a/assets/algolia_autocomplete_articles_plugin.js
+++ b/assets/algolia_autocomplete_articles_plugin.js
@@ -1,0 +1,2 @@
+window.algoliaShopify = window.algoliaShopify || {};
+// Placeholder for algolia_autocomplete_articles_plugin.js

--- a/assets/algolia_autocomplete_collections_plugin.js
+++ b/assets/algolia_autocomplete_collections_plugin.js
@@ -1,0 +1,2 @@
+window.algoliaShopify = window.algoliaShopify || {};
+// Placeholder for algolia_autocomplete_collections_plugin.js

--- a/assets/algolia_autocomplete_pages_plugin.js
+++ b/assets/algolia_autocomplete_pages_plugin.js
@@ -1,0 +1,2 @@
+window.algoliaShopify = window.algoliaShopify || {};
+// Placeholder for algolia_autocomplete_pages_plugin.js

--- a/assets/algolia_autocomplete_product_plugin.js
+++ b/assets/algolia_autocomplete_product_plugin.js
@@ -1,0 +1,2 @@
+window.algoliaShopify = window.algoliaShopify || {};
+// Placeholder for algolia_autocomplete_product_plugin.js

--- a/assets/algolia_autocomplete_suggestions_plugin.js
+++ b/assets/algolia_autocomplete_suggestions_plugin.js
@@ -1,0 +1,2 @@
+window.algoliaShopify = window.algoliaShopify || {};
+// Placeholder for algolia_autocomplete_suggestions_plugin.js

--- a/assets/algolia_config.js
+++ b/assets/algolia_config.js
@@ -1,0 +1,6 @@
+window.algoliaShopify = window.algoliaShopify || {};
+window.algoliaShopify.config = {
+  appId: '{{ shop.metafields.algolia_search.app_id | default: "" }}',
+  apiKey: '{{ shop.metafields.algolia_search.search_api_key | default: "" }}',
+  indexPrefix: '{{ shop.metafields.algolia_search.index_prefix | default: "" }}'
+};

--- a/assets/algolia_dependency_font-awesome-4-4-0.min.css
+++ b/assets/algolia_dependency_font-awesome-4-4-0.min.css
@@ -1,0 +1,1 @@
+@import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/css/font-awesome.min.css');

--- a/assets/algolia_externals.js
+++ b/assets/algolia_externals.js
@@ -1,0 +1,2 @@
+window.algoliaShopify = window.algoliaShopify || {};
+// Placeholder for algolia_externals.js

--- a/assets/algolia_facets.js
+++ b/assets/algolia_facets.js
@@ -1,0 +1,2 @@
+window.algoliaShopify = window.algoliaShopify || {};
+// Placeholder for algolia_facets.js

--- a/assets/algolia_helpers.js
+++ b/assets/algolia_helpers.js
@@ -1,0 +1,2 @@
+window.algoliaShopify = window.algoliaShopify || {};
+// Placeholder for algolia_helpers.js

--- a/assets/algolia_init.js
+++ b/assets/algolia_init.js
@@ -1,0 +1,10 @@
+window.algoliaShopify = window.algoliaShopify || {};
+(function(cfg){
+  if(!cfg.appId || !cfg.apiKey){
+    console.warn('Algolia credentials missing');
+    return;
+  }
+  if (typeof algoliasearch !== 'undefined') {
+    window.algoliaShopify.client = algoliasearch(cfg.appId, cfg.apiKey);
+  }
+})(window.algoliaShopify.config || {});

--- a/assets/algolia_instant_search.js
+++ b/assets/algolia_instant_search.js
@@ -1,0 +1,2 @@
+window.algoliaShopify = window.algoliaShopify || {};
+// Placeholder for algolia_instant_search.js

--- a/assets/algolia_sort_orders.js
+++ b/assets/algolia_sort_orders.js
@@ -1,0 +1,2 @@
+window.algoliaShopify = window.algoliaShopify || {};
+// Placeholder for algolia_sort_orders.js

--- a/assets/algolia_translations.js
+++ b/assets/algolia_translations.js
@@ -1,0 +1,2 @@
+window.algoliaShopify = window.algoliaShopify || {};
+// Placeholder for algolia_translations.js

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -10,8 +10,11 @@
     <link rel="preconnect dns-prefetch" href="https://conf.config-security.com/" crossorigin>
     <link rel="preconnect dns-prefetch" href="https://cdn.intelligems.io/" crossorigin>
 
-    <link rel="preload" href="{{ 'algolia_config.js' | asset_url }}" as="script">
-    <link rel="preload" href="{{ 'algolia_init.js' | asset_url }}" as="script">
+    {% if template.name contains 'search' %}
+      <link rel="preload" href="{{ 'algolia_config.js' | asset_url }}" as="script">
+      <link rel="preload" href="{{ 'algolia_init.js' | asset_url }}" as="script">
+      <link rel="preload" href="{{ 'algolia_dependency_font-awesome-4-4-0.min.css' | asset_url }}" as="style">
+    {% endif %}
 
     <link rel="preload" href="{{ '_proteus-utils.js' | asset_url }}" as="script">
     <link rel="preload" href="{{ '_proteus-treatments.js' | asset_url }}" as="script">
@@ -19,7 +22,6 @@
 
     <link rel="preload" href="{{ 'creative-judgement.css' | asset_url }}" as="style">
     <link rel="preload" href="{{ 'proteus-treatments.css' | asset_url }}" as="style">
-    <link rel="preload" href="{{ 'algolia_dependency_font-awesome-4-4-0.min.css' | asset_url }}" as="style">
 
     <link rel="preload" href="{{ 'dtc-free-gift.css' | asset_url }}" as="style">
     <link rel="preload" href="{{ 'cart.js' | asset_url }}" as="script">
@@ -473,54 +475,56 @@
       <link rel="stylesheet" href="https://use.typekit.net/pmy6wae.css">
     {%- endif -%}
 
-    <!-- Algolia head -->
-    {{ 'algolia_config.js' | asset_url | script_tag }}
+    {% if template.name contains 'search' %}
+      <!-- Algolia head -->
+      {{ 'algolia_config.js' | asset_url | script_tag }}
 
-    <script type="text/template" id="template_algolia_money_format">
-      {% include 'algolia_money_format' %}
-    </script>
-    <script type="text/template" id="template_algolia_current_collection_id">
-      {% include 'algolia_current_collection_id' %}
-    </script>
-    <script type="text/template" id="template_algolia_autocomplete.css">
-      {% include 'algolia_autocomplete.css' %}
-    </script>
-    <script type="text/template" id="template_algolia_instant_search.css">
-      {% include 'algolia_instant_search.css' %}
-    </script>
-    {{ 'algolia_dependency_font-awesome-4-4-0.min.css' | asset_url | stylesheet_tag }}
-    {% include 'algolia_markets_init' %}
-    <script src="{{ 'algolia_externals.js' | asset_url }}" defer></script>
-    {{ 'algolia_init.js' | asset_url | script_tag }}
-    <script src="{{ 'algolia_translations.js' | asset_url }}" defer></script>
-    <script src="{{ 'algolia_helpers.js' | asset_url }}" defer></script>
-    <script src="{{ 'algolia_autocomplete_suggestions_plugin.js' | asset_url }}" defer></script>
-    <script src="{{ 'algolia_autocomplete_product_plugin.js' | asset_url }}" defer></script>
-    <script src="{{ 'algolia_autocomplete_collections_plugin.js' | asset_url }}" defer></script>
-    <script src="{{ 'algolia_autocomplete_articles_plugin.js' | asset_url }}" defer></script>
-    <script src="{{ 'algolia_autocomplete_pages_plugin.js' | asset_url }}" defer></script>
-    <script src="{{ 'algolia_autocomplete.js' | asset_url }}" defer></script>
-    <script src="{{ 'algolia_facets.js' | asset_url }}" defer></script>
-    <script src="{{ 'algolia_sort_orders.js' | asset_url }}" defer></script>
-    <script src="{{ 'algolia_instant_search.js' | asset_url }}" defer></script>
-    <script src="{{ 'algolia_analytics.js' | asset_url }}" defer></script>
-    {% include 'algolia_autocomplete' %}
-    {% include 'algolia_autocomplete_main_products_only' %}
-    {% include 'algolia_autocomplete_page' %}
-    {% include 'algolia_autocomplete_collection' %}
-    {% include 'algolia_autocomplete_article' %}
-    {% include 'algolia_autocomplete_product' %}
-    {% include 'algolia_autocomplete_suggestion' %}
-    {% include 'algolia_autocomplete_header' %}
-    {% include 'algolia_autocomplete_footer' %}
-    {% include 'algolia_autocomplete_no_results' %}
-    {% include 'algolia_instant_search' %}
-    {% include 'algolia_instant_search_stats' %}
-    {% include 'algolia_instant_search_facet_show_more' %}
-    {% include 'algolia_instant_search_facet_item' %}
-    {% include 'algolia_instant_search_product' %}
-    {% include 'algolia_instant_search_no_result' %}
-    <!-- /Algolia head -->
+      <script type="text/template" id="template_algolia_money_format">
+        {% include 'algolia_money_format' %}
+      </script>
+      <script type="text/template" id="template_algolia_current_collection_id">
+        {% include 'algolia_current_collection_id' %}
+      </script>
+      <script type="text/template" id="template_algolia_autocomplete.css">
+        {% include 'algolia_autocomplete.css' %}
+      </script>
+      <script type="text/template" id="template_algolia_instant_search.css">
+        {% include 'algolia_instant_search.css' %}
+      </script>
+      {{ 'algolia_dependency_font-awesome-4-4-0.min.css' | asset_url | stylesheet_tag }}
+      {% include 'algolia_markets_init' %}
+      <script src="{{ 'algolia_externals.js' | asset_url }}" defer></script>
+      {{ 'algolia_init.js' | asset_url | script_tag }}
+      <script src="{{ 'algolia_translations.js' | asset_url }}" defer></script>
+      <script src="{{ 'algolia_helpers.js' | asset_url }}" defer></script>
+      <script src="{{ 'algolia_autocomplete_suggestions_plugin.js' | asset_url }}" defer></script>
+      <script src="{{ 'algolia_autocomplete_product_plugin.js' | asset_url }}" defer></script>
+      <script src="{{ 'algolia_autocomplete_collections_plugin.js' | asset_url }}" defer></script>
+      <script src="{{ 'algolia_autocomplete_articles_plugin.js' | asset_url }}" defer></script>
+      <script src="{{ 'algolia_autocomplete_pages_plugin.js' | asset_url }}" defer></script>
+      <script src="{{ 'algolia_autocomplete.js' | asset_url }}" defer></script>
+      <script src="{{ 'algolia_facets.js' | asset_url }}" defer></script>
+      <script src="{{ 'algolia_sort_orders.js' | asset_url }}" defer></script>
+      <script src="{{ 'algolia_instant_search.js' | asset_url }}" defer></script>
+      <script src="{{ 'algolia_analytics.js' | asset_url }}" defer></script>
+      {% include 'algolia_autocomplete' %}
+      {% include 'algolia_autocomplete_main_products_only' %}
+      {% include 'algolia_autocomplete_page' %}
+      {% include 'algolia_autocomplete_collection' %}
+      {% include 'algolia_autocomplete_article' %}
+      {% include 'algolia_autocomplete_product' %}
+      {% include 'algolia_autocomplete_suggestion' %}
+      {% include 'algolia_autocomplete_header' %}
+      {% include 'algolia_autocomplete_footer' %}
+      {% include 'algolia_autocomplete_no_results' %}
+      {% include 'algolia_instant_search' %}
+      {% include 'algolia_instant_search_stats' %}
+      {% include 'algolia_instant_search_facet_show_more' %}
+      {% include 'algolia_instant_search_facet_item' %}
+      {% include 'algolia_instant_search_product' %}
+      {% include 'algolia_instant_search_no_result' %}
+      <!-- /Algolia head -->
+    {% endif %}
 
     {{ 'dtc-free-gift.css' | asset_url | stylesheet_tag }}
 


### PR DESCRIPTION
## Summary
- restore Algolia placeholder assets
- load Algolia scripts/snippets only on search templates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689651400a588332ae96997076d5b7ec