### PR TITLE
Lazy load Klaviyo form in footer

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -94,12 +94,7 @@
 
 
 
-              <div class="signup-form">
-                
-                <style>
-                .klaviyo-form-TqwXDs form button { height: 26px; font-weight: 400; }
-                .klaviyo-form-TqwXDs form input { border-radius: 4px; }</style>
-                <div class="klaviyo-form-TqwXDs"></div>
+              {% render 'klaviyo-footer-signup' %}
                 {% comment %}
                 {% form 'customer', id: 'footer_newsletter_signup' %}
                   {% if form.posted_successfully? %}

--- a/snippets/klaviyo-footer-signup.liquid
+++ b/snippets/klaviyo-footer-signup.liquid
@@ -1,0 +1,54 @@
+<div id="klaviyo-footer-signup" class="signup-form">
+  <div class="klaviyo-form-TqwXDs"></div>
+</div>
+{% style %}
+.klaviyo-form-TqwXDs form button { height: 26px; font-weight: 400; }
+.klaviyo-form-TqwXDs form input { border-radius: 4px; }
+{% endstyle %}
+<script>
+(function() {
+  var container = document.getElementById('klaviyo-footer-signup');
+  if (!container) return;
+  var hasLoaded = false;
+  function loadScript() {
+    if (hasLoaded) return;
+    hasLoaded = true;
+    if (!window._klaviyoPromise) {
+      window._klaviyoPromise = new Promise(function(resolve) {
+        if (window.klaviyo) {
+          return resolve(window.klaviyo);
+        }
+        var existing = document.querySelector('script[src*="klaviyo.com/media/js/onsite/onsite.js"]');
+        if (existing) {
+          existing.addEventListener('load', function() { resolve(window.klaviyo); });
+          return;
+        }
+        var script = document.createElement('script');
+        script.async = true;
+        script.src = 'https://a.klaviyo.com/media/js/onsite/onsite.js';
+        script.onload = function() {
+          if (window.klaviyo && typeof window.klaviyo.init === 'function') {
+            window.klaviyo.init({ account: 'NMZKLp', platform: 'shopify' });
+          }
+          resolve(window.klaviyo);
+        };
+        document.head.appendChild(script);
+      });
+    }
+  }
+  function onIntersect(entries, observer) {
+    entries.forEach(function(entry) {
+      if (entry.isIntersecting) {
+        observer.disconnect();
+        loadScript();
+      }
+    });
+  }
+  if ('IntersectionObserver' in window) {
+    var observer = new IntersectionObserver(onIntersect);
+    observer.observe(container);
+  } else {
+    loadScript();
+  }
+})();
+</script>


### PR DESCRIPTION
## Summary
- replace inline Klaviyo form markup in footer with component
- add component to load Klaviyo script on intersection and scope form styles

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_b_68956eb6eda48332a8bab29675a5538b