### PR TITLE
docs: clarify header overlap and alt logo behavior

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -257,6 +257,7 @@
         animationEnabledMobile: {{ settings.animation_enabled_mobile | json }}
       };
 
+      // Detects when the first section overlaps the header to toggle header-section-overlap
       theme.checkViewportFillers = function() {
         var toggleState = false;
         var elPageContent = document.getElementById('page-content');
@@ -274,6 +275,7 @@
         }
       };
 
+      // Swaps to an alternate logo when .needs-alt-logo elements intersect the header midpoint
       theme.assessAltLogo = function() {
         var elsOverlappers = document.querySelectorAll('.needs-alt-logo');
         var useAltLogo = false;


### PR DESCRIPTION
## Summary
- document detection of header-section-overlap
- note alt logo swap when `.needs-alt-logo` crosses header midpoint

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6895758f4bac833281e800d50dd515d5