### PR TITLE
docs: clarify related product metadata

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -300,6 +300,10 @@
     {% render 'builder-head' %}
 
     <script type="text/javascript">
+      // Build window.related so JavaScript can consume upsell/related product
+      // metadata including variant availability. Expected keys include:
+      // prod_id, prod_price, prod_title, prod_url, prod_thumb, and size
+      // variant handles (xxsm, xsm, sm, md, lg, xlg, x2lg, x3lg).
       window.related = {
       pdp_products:{
       {% for upsell_product in product.metafields.custom.related_products.value %}


### PR DESCRIPTION
## Summary
- document `window.related` metadata keys for upsell/related products

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68966121907c833286c9d36fdab96770