### PR TITLE
Clean up hero slider initialization

### DIFF
--- a/assets/dtc-hero-slider.js
+++ b/assets/dtc-hero-slider.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', function(){
   var sliders = document.querySelectorAll('.dtc-hero-slider');
   sliders.forEach(function(slider) {
+    // Configure navigation controls and optional looping for each slider
     var swiper = new Swiper(slider, {
       navigation: {
         nextEl: slider.parentElement.querySelector('.swiper-button-next'),
@@ -11,7 +12,6 @@ document.addEventListener('DOMContentLoaded', function(){
     });
     //count the amound of slides in each slider
     var slides = slider.querySelectorAll('.swiper-slide').length;
-    console.log(slides);
   });
 });
 


### PR DESCRIPTION
## Summary
- remove stray `console.log` from hero slider script
- clarify Swiper initialization with a brief comment

## Testing
- `node --check assets/dtc-hero-slider.js`
- `node - <<'NODE'
let called = false;
let passedOptions;
global.document = {
  querySelectorAll: () => [{
    parentElement: { querySelector: () => ({}) },
    dataset: { loopSlider: 'true' },
    querySelectorAll: () => [{}, {}]
  }],
  addEventListener: (evt, cb) => { if (evt === 'DOMContentLoaded') cb(); }
};
global.Swiper = function(element, options) {
  called = true;
  passedOptions = options;
};
require('./assets/dtc-hero-slider.js');
console.log('Swiper initialized:', called);
console.log('Options:', JSON.stringify(passedOptions));
NODE`

------
https://chatgpt.com/codex/tasks/task_b_68966126b3b48332925b380c1feb72c6