### PR TITLE
Organize custom assets into subfolders and add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Jambys Theme
+
+This theme stores front-end assets in organized subfolders:
+
+- `assets/scripts/proteus` – custom Proteus experiment scripts
+- `assets/styles/proteus` – styles related to Proteus experiments
+- `assets/scripts/dtc` – scripts for direct-to-consumer features
+- `assets/styles/dtc` – styles for direct-to-consumer features
+
+Each custom script or style includes a header comment describing its purpose. New assets should follow this structure and include similar documentation.
+
+Run `npm test` to verify the placeholder test script.

--- a/assets/scripts/dtc/dtc-hero-slider.js
+++ b/assets/scripts/dtc/dtc-hero-slider.js
@@ -1,3 +1,4 @@
+// Initializes DTC hero slider components
 document.addEventListener('DOMContentLoaded', function(){
   var sliders = document.querySelectorAll('.dtc-hero-slider');
   sliders.forEach(function(slider) {

--- a/assets/scripts/dtc/dtc-upsell-feature.js
+++ b/assets/scripts/dtc/dtc-upsell-feature.js
@@ -1,3 +1,4 @@
+// Handles DTC upsell feature interactions
 // Custom function to observe mutations in the DOM
 document.querySelectorEver = (selector, callback) => {
     const targetNode = document.querySelector(selector);

--- a/assets/scripts/proteus/_proteus-housefit.js
+++ b/assets/scripts/proteus/_proteus-housefit.js
@@ -1,3 +1,4 @@
+// Proteus housefit experiment script
 waitUntil(() => {
   return (
     window.sessionStorage.getItem("JMBY-48") || getParam("qa") == "JMBY-48"

--- a/assets/scripts/proteus/_proteus-treatments.js
+++ b/assets/scripts/proteus/_proteus-treatments.js
@@ -1,3 +1,4 @@
+// Proteus treatments experiment script
 console.log("init Proteus treatments - v1.08");
 
 window.sessionStorage.setItem("disable_discount_threshold", true);

--- a/assets/scripts/proteus/_proteus-utils.js
+++ b/assets/scripts/proteus/_proteus-utils.js
@@ -1,3 +1,4 @@
+// Shared utilities for Proteus experiments
 "use strict";
 
 console.log("init Proteus utils - v1.05");

--- a/assets/styles/dtc/dtc-collection-slider.css
+++ b/assets/styles/dtc/dtc-collection-slider.css
@@ -1,3 +1,4 @@
+/* Styles for DTC collection slider */
 .slider-images .swiper-pagination {
   height: 28px;
   bottom: 0;

--- a/assets/styles/dtc/dtc-free-gift.css
+++ b/assets/styles/dtc/dtc-free-gift.css
@@ -1,3 +1,4 @@
+/* Styles for DTC free gift feature */
 .cart-line-items_container {
     padding-top: 0;
     height: calc(100% - 150px);

--- a/assets/styles/dtc/dtc-hero-slider.css
+++ b/assets/styles/dtc/dtc-hero-slider.css
@@ -1,3 +1,4 @@
+/* Styles for DTC hero slider */
   .dtc-hero-slider {
     overflow: hidden;
   }

--- a/assets/styles/dtc/dtc-upsell-feature.css
+++ b/assets/styles/dtc/dtc-upsell-feature.css
@@ -1,3 +1,4 @@
+/* Styles for DTC upsell feature */
 .dtc-single-upsell {
     display: none;
     padding-bottom: 100px;

--- a/assets/styles/proteus/proteus-treatments.css
+++ b/assets/styles/proteus/proteus-treatments.css
@@ -1,3 +1,4 @@
+/* Styles for Proteus treatments experiment */
 .cart-drawer.active-dialog{
   z-index: 9999999999 !important;
 }

--- a/docs/builder-components.md
+++ b/docs/builder-components.md
@@ -5,7 +5,7 @@ The theme no longer includes builder-specific templates or snippets. Legacy buil
 Remaining builder references exist only in styles and class names:
 
 - `assets/outfit-builder.css`
-- `assets/proteus-treatments.css`
+- `assets/styles/proteus/proteus-treatments.css`
 - `sections/color-swatches.liquid`, `sections/color-swatches-2.liquid`, and `sections/color-swatches-3.liquid` use the `js-builder-color-swatch` class for swatch styling.
 
 These artifacts can be cleaned up in the future if the builder functionality is fully deprecated.

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -16,14 +16,14 @@
       <link rel="preload" href="{{ 'algolia_dependency_font-awesome-4-4-0.min.css' | asset_url }}" as="style">
     {% endif %}
 
-    <link rel="preload" href="{{ '_proteus-utils.js' | asset_url }}" as="script">
-    <link rel="preload" href="{{ '_proteus-treatments.js' | asset_url }}" as="script">
-    <link rel="preload" href="{{ '_proteus-housefit.js' | asset_url }}" as="script">
+    <link rel="preload" href="{{ 'scripts/proteus/_proteus-utils.js' | asset_url }}" as="script">
+    <link rel="preload" href="{{ 'scripts/proteus/_proteus-treatments.js' | asset_url }}" as="script">
+    <link rel="preload" href="{{ 'scripts/proteus/_proteus-housefit.js' | asset_url }}" as="script">
 
     <link rel="preload" href="{{ 'creative-judgement.css' | asset_url }}" as="style">
-    <link rel="preload" href="{{ 'proteus-treatments.css' | asset_url }}" as="style">
+    <link rel="preload" href="{{ 'styles/proteus/proteus-treatments.css' | asset_url }}" as="style">
 
-    <link rel="preload" href="{{ 'dtc-free-gift.css' | asset_url }}" as="style">
+    <link rel="preload" href="{{ 'styles/dtc/dtc-free-gift.css' | asset_url }}" as="style">
 
 
     {% render 'replo-head' %}
@@ -71,15 +71,15 @@
 
     {% if template contains 'collection' %}
       <link rel="preload" href="{{ 'top-filter-collection.css' | asset_url }}" as="style">
-      <link rel="preload" href="{{ 'dtc-collection-slider.css' | asset_url }}" as="style">
+      <link rel="preload" href="{{ 'styles/dtc/dtc-collection-slider.css' | asset_url }}" as="style">
       <link rel="preload" href="https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.css" as="style">
     {% endif %}
-    {{ '_proteus-utils.js' | asset_url | script_tag }}
-    {{ '_proteus-treatments.js' | asset_url | script_tag }}
-    {{ '_proteus-housefit.js' | asset_url | script_tag }}
+    {{ 'scripts/proteus/_proteus-utils.js' | asset_url | script_tag }}
+    {{ 'scripts/proteus/_proteus-treatments.js' | asset_url | script_tag }}
+    {{ 'scripts/proteus/_proteus-housefit.js' | asset_url | script_tag }}
     {% if template contains 'collection' %}
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.css">
-      {{ 'dtc-collection-slider.css' | asset_url | stylesheet_tag }}
+      {{ 'styles/dtc/dtc-collection-slider.css' | asset_url | stylesheet_tag }}
     {% endif %}
 
     <meta name="google-site-verification" content="sB4YVjrMTVA3cn7Th91xY8uSx5pn07OcLt7u8LueKd4">
@@ -183,12 +183,12 @@
 
     {{ 'styles.css' | asset_url | stylesheet_tag }}
     {{ 'creative-judgement.css' | asset_url | stylesheet_tag }}
-    {{ 'proteus-treatments.css' | asset_url | stylesheet_tag }}
+    {{ 'styles/proteus/proteus-treatments.css' | asset_url | stylesheet_tag }}
 
     {% if template contains 'collection' %}
       {{ 'top-filter-collection.css' | asset_url | stylesheet_tag }}
     {% endif %}
-    {{ 'dtc-hero-slider.css' | asset_url | stylesheet_tag }}
+    {{ 'styles/dtc/dtc-hero-slider.css' | asset_url | stylesheet_tag }}
     {%- capture content_for_header -%}
     {%- if tinyscript -%}
       {{ content_for_header }}
@@ -200,7 +200,7 @@
     {% render 'header-content-app-filter', content_for_header: content_for_header %}
   {%- endcapture -%}
     {{ content_for_header }}
-    {{ 'dtc-hero-slider.js' | asset_url | script_tag }}
+    {{ 'scripts/dtc/dtc-hero-slider.js' | asset_url | script_tag }}
     <script>
       document.documentElement.className = document.documentElement.className.replace('no-js', 'js');
       window.theme = window.theme || {};{% if settings.currency_code_enabled %}
@@ -531,7 +531,7 @@
       <!-- /Algolia head -->
     {% endif %}
 
-    {{ 'dtc-free-gift.css' | asset_url | stylesheet_tag }}
+    {{ 'styles/dtc/dtc-free-gift.css' | asset_url | stylesheet_tag }}
 
     <script src="{{ 'cart.js' | asset_url }}"></script>
 
@@ -806,7 +806,7 @@
 
     {% if template contains 'product' %}
       <script src="{{ 'product-features.js' | asset_url }}" defer></script>
-      <script src="{{ 'dtc-upsell-feature.js' | asset_url }}" async></script>
+      <script src="{{ 'scripts/dtc/dtc-upsell-feature.js' | asset_url }}" async></script>
     {% endif %}
 
     {% if template contains 'collection' %}
@@ -932,7 +932,7 @@
     </script>
 
     {% if template contains 'product' %}
-      <script src="{{ 'dtc-upsell-feature.js' | asset_url }}"></script>
+      <script src="{{ 'scripts/dtc/dtc-upsell-feature.js' | asset_url }}"></script>
       <script src="{{ 'colorSwatchToggler.js' | asset_url }}"></script>
     {% endif %}
 

--- a/package.json
+++ b/package.json
@@ -1,14 +1,9 @@
 {
-  "name": "jambys-current-theme-repository",
+  "name": "jambys-theme",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "private": true,
   "scripts": {
     "build": "node build.js",
-    "test": "echo \"No tests\""
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "type": "commonjs"
+    "test": "echo \"No tests\" && exit 0"
+  }
 }

--- a/sections/dtc-featured-collection.liquid
+++ b/sections/dtc-featured-collection.liquid
@@ -1,4 +1,4 @@
-{{ 'dtc-upsell-feature.css' | asset_url | stylesheet_tag }}
+{{ 'styles/dtc/dtc-upsell-feature.css' | asset_url | stylesheet_tag }}
 
 {% style %}
   {% if section.settings.title_alignment == 'center' %}


### PR DESCRIPTION
## Summary
- group Proteus and DTC scripts/styles into dedicated `scripts/` and `styles/` subfolders
- add header comments to custom scripts and styles
- add README and update docs and package.json with placeholder test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68977017becc8332abc6d7c4da0c8d69