### PR TITLE
Remove duplicate upsell feature script inclusion

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -932,7 +932,6 @@
     </script>
 
     {% if template contains 'product' %}
-      <script src="{{ 'scripts/dtc/dtc-upsell-feature.js' | asset_url }}"></script>
       <script src="{{ 'colorSwatchToggler.js' | asset_url }}"></script>
     {% endif %}
 


### PR DESCRIPTION
## Summary
- Ensure dtc upsell feature script is loaded only once on product templates

## Testing
- `node -e "const fs=require('fs');const text=fs.readFileSync('layout/theme.liquid','utf8');console.log((text.match(/scripts\/dtc\/dtc-upsell-feature.js/g)||[]).length)"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6898007d434083329ca0d26448c052fb