### PR TITLE
refactor: relocate experiment scripts and enable conditional loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 This theme stores front-end assets in organized subfolders:
 
-- `assets/scripts/proteus` – custom Proteus experiment scripts
+- `assets/experiments/proteus` – custom Proteus experiment scripts
 - `assets/styles/proteus` – styles related to Proteus experiments
-- `assets/scripts/dtc` – scripts for direct-to-consumer features
+- `assets/experiments/dtc` – scripts for direct-to-consumer experiments
 - `assets/styles/dtc` – styles for direct-to-consumer features
+
+Experiment scripts are loaded only when their matching theme settings are enabled.
 
 Each custom script or style includes a header comment describing its purpose. New assets should follow this structure and include similar documentation.
 

--- a/assets/experiments/dtc/dtc-hero-slider.js
+++ b/assets/experiments/dtc/dtc-hero-slider.js
@@ -1,4 +1,5 @@
 // Initializes DTC hero slider components
+// Only loads when the "Enable DTC experiments" theme setting is enabled.
 document.addEventListener('DOMContentLoaded', function(){
   var sliders = document.querySelectorAll('.dtc-hero-slider');
   sliders.forEach(function(slider) {

--- a/assets/experiments/dtc/dtc-upsell-feature.js
+++ b/assets/experiments/dtc/dtc-upsell-feature.js
@@ -1,4 +1,5 @@
 // Handles DTC upsell feature interactions
+// Loaded conditionally when "Enable DTC experiments" setting is active.
 // Custom function to observe mutations in the DOM
 document.querySelectorEver = (selector, callback) => {
     const targetNode = document.querySelector(selector);

--- a/assets/experiments/proteus/_proteus-housefit.js
+++ b/assets/experiments/proteus/_proteus-housefit.js
@@ -1,4 +1,5 @@
 // Proteus housefit experiment script
+// Enabled when the "Enable Proteus experiments" setting is turned on.
 waitUntil(() => {
   return (
     window.sessionStorage.getItem("JMBY-48") || getParam("qa") == "JMBY-48"

--- a/assets/experiments/proteus/_proteus-treatments.js
+++ b/assets/experiments/proteus/_proteus-treatments.js
@@ -1,4 +1,5 @@
 // Proteus treatments experiment script
+// Activated via the "Enable Proteus experiments" theme setting.
 console.log("init Proteus treatments - v1.08");
 
 window.sessionStorage.setItem("disable_discount_threshold", true);

--- a/assets/experiments/proteus/_proteus-utils.js
+++ b/assets/experiments/proteus/_proteus-utils.js
@@ -1,4 +1,5 @@
 // Shared utilities for Proteus experiments
+// Loaded only when the "Enable Proteus experiments" theme setting is active.
 "use strict";
 
 console.log("init Proteus utils - v1.05");

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -845,5 +845,22 @@
         "label": "Destination Name."
       }
     ]
+  },
+  {
+    "name": "Experiments",
+    "settings": [
+      {
+        "type": "checkbox",
+        "id": "enable_proteus_experiments",
+        "label": "Enable Proteus experiments",
+        "default": false
+      },
+      {
+        "type": "checkbox",
+        "id": "enable_dtc_experiments",
+        "label": "Enable DTC experiments",
+        "default": false
+      }
+    ]
   }
 ]

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -16,13 +16,15 @@
       <link rel="preload" href="{{ 'algolia_dependency_font-awesome-4-4-0.min.css' | asset_url }}" as="style">
     {% endif %}
 
-    <link rel="preload" href="{{ 'scripts/proteus/_proteus-utils.js' | asset_url }}" as="script">
-    <link rel="preload" href="{{ 'scripts/proteus/_proteus-treatments.js' | asset_url }}" as="script">
-    <link rel="preload" href="{{ 'scripts/proteus/_proteus-housefit.js' | asset_url }}" as="script">
+    {% if settings.enable_proteus_experiments %}
+      {% comment %} Preload Proteus experiment assets when enabled {% endcomment %}
+      <link rel="preload" href="{{ 'experiments/proteus/_proteus-utils.js' | asset_url }}" as="script">
+      <link rel="preload" href="{{ 'experiments/proteus/_proteus-treatments.js' | asset_url }}" as="script">
+      <link rel="preload" href="{{ 'experiments/proteus/_proteus-housefit.js' | asset_url }}" as="script">
+      <link rel="preload" href="{{ 'styles/proteus/proteus-treatments.css' | asset_url }}" as="style">
+    {% endif %}
 
     <link rel="preload" href="{{ 'creative-judgement.css' | asset_url }}" as="style">
-    <link rel="preload" href="{{ 'styles/proteus/proteus-treatments.css' | asset_url }}" as="style">
-
     <link rel="preload" href="{{ 'styles/dtc/dtc-free-gift.css' | asset_url }}" as="style">
 
 
@@ -74,9 +76,6 @@
       <link rel="preload" href="{{ 'styles/dtc/dtc-collection-slider.css' | asset_url }}" as="style">
       <link rel="preload" href="https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.css" as="style">
     {% endif %}
-    {{ 'scripts/proteus/_proteus-utils.js' | asset_url | script_tag }}
-    {{ 'scripts/proteus/_proteus-treatments.js' | asset_url | script_tag }}
-    {{ 'scripts/proteus/_proteus-housefit.js' | asset_url | script_tag }}
     {% if template contains 'collection' %}
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.css">
       {{ 'styles/dtc/dtc-collection-slider.css' | asset_url | stylesheet_tag }}
@@ -183,12 +182,22 @@
 
     {{ 'styles.css' | asset_url | stylesheet_tag }}
     {{ 'creative-judgement.css' | asset_url | stylesheet_tag }}
-    {{ 'styles/proteus/proteus-treatments.css' | asset_url | stylesheet_tag }}
+    {% if settings.enable_proteus_experiments %}
+      {% comment %} Proteus experiment styles and scripts {% endcomment %}
+      {{ 'styles/proteus/proteus-treatments.css' | asset_url | stylesheet_tag }}
+      {{ 'experiments/proteus/_proteus-utils.js' | asset_url | script_tag }}
+      {{ 'experiments/proteus/_proteus-treatments.js' | asset_url | script_tag }}
+      {{ 'experiments/proteus/_proteus-housefit.js' | asset_url | script_tag }}
+    {% endif %}
 
     {% if template contains 'collection' %}
       {{ 'top-filter-collection.css' | asset_url | stylesheet_tag }}
     {% endif %}
-    {{ 'styles/dtc/dtc-hero-slider.css' | asset_url | stylesheet_tag }}
+    {% if settings.enable_dtc_experiments %}
+      {% comment %} DTC experiment assets {% endcomment %}
+      {{ 'styles/dtc/dtc-hero-slider.css' | asset_url | stylesheet_tag }}
+      {{ 'experiments/dtc/dtc-hero-slider.js' | asset_url | script_tag }}
+    {% endif %}
     {%- capture content_for_header -%}
     {%- if tinyscript -%}
       {{ content_for_header }}
@@ -200,7 +209,6 @@
     {% render 'header-content-app-filter', content_for_header: content_for_header %}
   {%- endcapture -%}
     {{ content_for_header }}
-    {{ 'scripts/dtc/dtc-hero-slider.js' | asset_url | script_tag }}
     <script>
       document.documentElement.className = document.documentElement.className.replace('no-js', 'js');
       window.theme = window.theme || {};{% if settings.currency_code_enabled %}
@@ -806,7 +814,10 @@
 
     {% if template contains 'product' %}
       <script src="{{ 'product-features.js' | asset_url }}" defer></script>
-      <script src="{{ 'scripts/dtc/dtc-upsell-feature.js' | asset_url }}" async></script>
+      {% if settings.enable_dtc_experiments %}
+        {% comment %} DTC upsell experiment script {% endcomment %}
+        <script src="{{ 'experiments/dtc/dtc-upsell-feature.js' | asset_url }}" async></script>
+      {% endif %}
     {% endif %}
 
     {% if template contains 'collection' %}
@@ -932,7 +943,9 @@
     </script>
 
     {% if template contains 'product' %}
-      <script src="{{ 'scripts/dtc/dtc-upsell-feature.js' | asset_url }}"></script>
+      {% if settings.enable_dtc_experiments %}
+        <script src="{{ 'experiments/dtc/dtc-upsell-feature.js' | asset_url }}"></script>
+      {% endif %}
       <script src="{{ 'colorSwatchToggler.js' | asset_url }}"></script>
     {% endif %}
 


### PR DESCRIPTION
## Summary
- move Proteus and DTC experiment scripts into `assets/experiments`
- add theme settings to toggle Proteus and DTC experiment assets
- load Proteus and DTC scripts/styles only when experiments are enabled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68980328f9608332841fdb2c18f4dc19