### PR TITLE
Load Proteus utilities in checkout

### DIFF
--- a/layout/checkout.liquid
+++ b/layout/checkout.liquid
@@ -77,117 +77,28 @@
       </div>
       {{ tracking_code }}
   
-      <script>
-        // shim layer with setTimeout fallback
-        const requestAnimFrame = (function() {
-          return window.requestAnimationFrame || window.webkitRequestAnimationFrame || window.mozRequestAnimationFrame || function(callback) {
-            window.setTimeout(callback, 3000 / 60);
-          };
-        })();
-  
-        function waitUntil(test) {
-          return new Promise(function(resolve) {
-            (function poll() {
-              if (! test()) 
-                return requestAnimFrame(poll, 50);
-              
-              return resolve();
-            })();
-          });
-        };
-  
-        const observeSelector = (selector, callback, options = { timeout: null, once: false, onTimeout: null, document: window.document })=>{
-          let processed = new Map();
-        
-          if (options.timeout || options.onTimeout){
-            console.log('------------------------------------------------------------------------------------------------------------------------------');
-            console.log('WARNING: observeSelector options timeout and onTimeout are not yet implemented.');
-            console.log('------------------------------------------------------------------------------------------------------------------------------');
-          }
-        
-          let obs, isDone = false;
-          const done = ()=>{
-            if (!obs) console.warn('observeSelector failed to run done()');
-            if (obs) obs.disconnect();
-            processed = undefined;
-            obs = undefined;
-            return isDone = true;
-          };
-        
-          const processElement = el=>{
-            if (processed && !processed.has(el)) {
-              processed.set(el, true);
-              callback(el);
-              if (options.once){
-                done();
-                return true;
+        {{ 'scripts/proteus/_proteus-utils.js' | asset_url | script_tag }}
+        <script>
+          // JMBY-73
+          waitUntil(() => {
+            return document.querySelectorAll('input#checkout_buyer_accepts_marketing').length > 0 && document.querySelectorAll('input#ps_accepts_sms').length > 0;
+          }).then(() => {
+            let step1_form = document.querySelector('input#checkout_buyer_accepts_marketing').closest('form');
+            step1_form.addEventListener("submit", () => {
+              if(document.querySelector('input#checkout_buyer_accepts_marketing').checked){
+                ga('send', 'event', 'CRO', `Checkout Step 1 Submit`, 'Accept Marketing');
+              } else {
+                ga('send', 'event', 'CRO', `Checkout Step 1 Submit`, 'Decline Marketing');
               }
-            }
-          };
-        
-          const lookForSelector = (el = document) => {
-            if (el.matches && el.matches(selector)){
-              if (processElement(el)) return true;
-            }
-            if (el.querySelectorAll){
-              const elements = el.querySelectorAll(selector);
-              if (elements.length) {
-                for (let i = 0; i < elements.length; i++) {
-                  const el = elements[i];
-                  if (processElement(el)) return true;
-                }
+              if(document.querySelector('input#ps_accepts_sms').checked){
+                ga('send', 'event', 'CRO', `Checkout Step 1 Submit`, 'Accept SMS');
+              } else {
+                ga('send', 'event', 'CRO', `Checkout Step 1 Submit`, 'Decline SMS');
               }
-            }
-          };
-          lookForSelector();
-        
-          //We might finish before the mutation observer is necessary:
-          if (!isDone){
-            obs = new MutationObserver(mutationsList => {
-              mutationsList.forEach(record=>{
-                if (record && record.addedNodes && record.addedNodes.length){
-                  for (let i = 0; i < record.addedNodes.length; i++) {
-                    //Need to check from the parent element since sibling selectors can be thrown off if elements show up in non-sequential order
-                    const el = record.addedNodes[i].parentElement;
-                    // if (!el) console.warn('observeSelector element has no parent', record.addedNodes[i], record);
-                    //Note: This appears to also run when elements are removed from the DOM. If the element doesn't have a parent then we don't need to check it.
-                    if (el && lookForSelector(el)) return true;
-                  }
-                }
-              });
             });
-            obs.observe(options.document || document, {
-              attributes: false,
-              childList: true,
-              subtree: true
-            });
-          }
-        
-          return ()=>{
-            done();
-          };
-        }; //_observeSelector
-    
-        // JMBY-73
-        waitUntil(() => {
-          return document.querySelectorAll('input#checkout_buyer_accepts_marketing').length > 0 && document.querySelectorAll('input#ps_accepts_sms').length > 0;
-        }).then(() => {
-          let step1_form = document.querySelector('input#checkout_buyer_accepts_marketing').closest('form');
-          step1_form.addEventListener("submit", () => {
-            if(document.querySelector('input#checkout_buyer_accepts_marketing').checked){
-              ga('send', 'event', 'CRO', `Checkout Step 1 Submit`, 'Accept Marketing');      
-            } else {
-              ga('send', 'event', 'CRO', `Checkout Step 1 Submit`, 'Decline Marketing');      
-            }
-            if(document.querySelector('input#ps_accepts_sms').checked){
-              ga('send', 'event', 'CRO', `Checkout Step 1 Submit`, 'Accept SMS');    
-            } else {
-              ga('send', 'event', 'CRO', `Checkout Step 1 Submit`, 'Decline SMS');      
-            }
-          });
-        }).catch();
+          }).catch();
 
-        
-      </script>
+
+        </script>
     </body>
   </html>


### PR DESCRIPTION
## Summary
- avoid duplicating utilities by including `scripts/proteus/_proteus-utils.js` in checkout
- rely on shared waitUntil utility for marketing/sms analytics tracking

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6898032e25cc833289be685648551b7b