### PR TITLE
refactor: centralize product type logic

### DIFF
--- a/sections/product-diagram.liquid
+++ b/sections/product-diagram.liquid
@@ -1,16 +1,13 @@
-{% assign product_type = product.type | handleize %}
+{% comment %}
+  Section: Product Diagram
+  Purpose: Displays product-specific diagram images using collection metafields.
+  Key variables:
+  - product_type_handle: handleized product type for collection lookup
+  - has_product_switcher: true when product supports switching between variants
+{% endcomment %}
 
-{% if product.type == 'House Hoodie' %}
-  {% assign product_type = 'House Hoodies' | handleize %}
-{% endif %}
-{% if product.type == 'JamTee' %}
-  {% assign product_type = 'JamTees' | handleize %}
-{% endif %}
-{% assign has_product_switcher = false %}
-{% if product.type == 'Double Cozy Cloak' or product.type == 'Cozy Cloak' %}
-  {% assign has_product_switcher = true %}
-{% endif %}
-{% assign diagram_title = collections[product_type].metafields.diagram.collection_diagram_title %}
+{% include 'product-type-settings', product: product %}
+{% assign diagram_title = collections[product_type_handle].metafields.diagram.collection_diagram_title %}
 
 
 {%- unless section.settings.color_bg == blank -%}
@@ -53,10 +50,10 @@
   {% endif %}
   
   
-  {% if collections[product_type].metafields.diagram.collection_diagram_mobile.value.src and collections[product_type].metafields.diagram.product_type.value.src %}
+  {% if collections[product_type_handle].metafields.diagram.collection_diagram_mobile.value.src and collections[product_type_handle].metafields.diagram.product_type.value.src %}
     <picture>
-      <source srcset="{{ collections[product_type].metafields.diagram.collection_diagram_mobile.value.src | img_url: '720x', scale: 2 }}" media="(max-width: 767px)">
-      <img loading="lazy" src="{{ collections[product_type].metafields.diagram.product_type.value.src | img_url: '720x', scale: 2 }}">
+      <source srcset="{{ collections[product_type_handle].metafields.diagram.collection_diagram_mobile.value.src | img_url: '720x', scale: 2 }}" media="(max-width: 767px)">
+      <img loading="lazy" src="{{ collections[product_type_handle].metafields.diagram.product_type.value.src | img_url: '720x', scale: 2 }}">
     </picture>
   {% endif %}
 </div>

--- a/snippets/product-type-settings.liquid
+++ b/snippets/product-type-settings.liquid
@@ -1,0 +1,16 @@
+{% comment %}
+  Helper snippet to normalize product type variables for Horizon.
+  Accepts:
+  - product: product object
+  Outputs:
+  - product_type_handle: handleized product type used for collection lookup
+  - has_product_switcher: boolean indicating if product has variant switcher
+{% endcomment %}
+
+{% assign product_type_handle = product.type | handleize %}
+{% if product.type == 'House Hoodie' %}
+  {% assign product_type_handle = 'House Hoodies' | handleize %}
+{% elsif product.type == 'JamTee' %}
+  {% assign product_type_handle = 'JamTees' | handleize %}
+{% endif %}
+{% assign has_product_switcher = product.type == 'Double Cozy Cloak' or product.type == 'Cozy Cloak' %}


### PR DESCRIPTION
## Summary
- document purpose and key variables in product diagram section
- centralize product type handling via snippet for consistent Horizon mapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68980331fc9c83328e5402614665cc1f