### PR TITLE
Rename Proteus experiments to generic experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 This theme stores front-end assets in organized subfolders:
 
-- `assets/scripts/experiments` – JavaScript for theme experiments (e.g., `proteus-utils.js`, `proteus-treatments.js`)
-- `assets/styles/proteus` – styles related to Proteus experiments
+- `assets/scripts/experiments` – JavaScript for theme experiments (e.g., `experiments-utils.js`, `experiments-treatments.js`)
+- `assets/styles/experiments` – styles related to experiments
 - `assets/experiments/dtc` – scripts for direct-to-consumer experiments
 - `assets/styles/dtc` – styles for direct-to-consumer features
 
-Experiment scripts are loaded only when their matching theme settings are enabled. The `experiment-quicklinks` class (formerly `proteus-quicklinks`) marks quicklink blocks used by Proteus experiments.
+Experiment scripts are loaded only when their matching theme settings are enabled. The `experiment-quicklinks` class marks quicklink blocks used by experiments.
 
 Each custom script or style includes a header comment describing its purpose. New assets should follow this structure and include similar documentation.
 

--- a/assets/scripts/experiments/experiments-housefit.js
+++ b/assets/scripts/experiments/experiments-housefit.js
@@ -1,5 +1,5 @@
-// Proteus housefit experiment script
-// Enabled when the "Enable Proteus experiments" setting is turned on.
+// Housefit experiment script
+// Enabled when the "Enable experiments" setting is turned on.
 waitUntil(() => {
   return (
     window.sessionStorage.getItem("JMBY-48") || getParam("qa") == "JMBY-48"

--- a/assets/scripts/experiments/experiments-treatments.js
+++ b/assets/scripts/experiments/experiments-treatments.js
@@ -1,6 +1,6 @@
-// Proteus treatments experiment script
-// Activated via the "Enable Proteus experiments" theme setting.
-console.log("init Proteus treatments - v1.08");
+// Treatments experiment script
+// Activated via the "Enable experiments" theme setting.
+console.log("init experiment treatments - v1.08");
 
 window.sessionStorage.setItem("disable_discount_threshold", true);
 

--- a/assets/scripts/experiments/experiments-utils.js
+++ b/assets/scripts/experiments/experiments-utils.js
@@ -1,8 +1,8 @@
-// Shared utilities for Proteus experiments
-// Loaded only when the "Enable Proteus experiments" theme setting is active.
+// Shared utilities for experiments
+// Loaded only when the "Enable experiments" theme setting is active.
 "use strict";
 
-console.log("init Proteus utils - v1.05");
+console.log("init experiment utils - v1.05");
 
 let variation;
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -15235,7 +15235,7 @@ div.dtc-collection-name > h1 {
   align-items: end;
 }
 
-/* Proteus experiment quicklinks */
+/* Experiment quicklinks */
 .dtc-collection-results .experiment-quicklinks.quicklinks-desktop {
   width: 80%;
   display: flex;

--- a/assets/styles/experiments/experiments-treatments.css
+++ b/assets/styles/experiments/experiments-treatments.css
@@ -1,4 +1,4 @@
-/* Styles for Proteus treatments experiment */
+/* Styles for experiment treatments */
 .cart-drawer.active-dialog{
   z-index: 9999999999 !important;
 }

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -877,8 +877,8 @@
       },
       {
         "type": "checkbox",
-        "id": "enable_proteus_experiments",
-        "label": "Enable Proteus experiments",
+        "id": "enable_experiments",
+        "label": "Enable experiments",
         "default": false
       },
       {

--- a/docs/builder-components.md
+++ b/docs/builder-components.md
@@ -5,10 +5,10 @@ The theme no longer includes builder-specific templates or snippets. Legacy buil
 Remaining builder references exist only in styles, scripts, and class names:
 
 - `assets/outfit-builder.css`
-- `assets/styles/proteus/proteus-treatments.css`
-- `assets/scripts/experiments/proteus-utils.js`, `proteus-treatments.js`, `proteus-housefit.js`
+- `assets/styles/experiments/experiments-treatments.css`
+- `assets/scripts/experiments/experiments-utils.js`, `experiments-treatments.js`, `experiments-housefit.js`
 - `sections/color-swatches.liquid`, `sections/color-swatches-2.liquid`, and `sections/color-swatches-3.liquid` use the `js-builder-color-swatch` class for swatch styling.
 
-Proteus experiment quicklinks use the `experiment-quicklinks` class, providing a neutral label for components tied to these tests.
+Experiment quicklinks use the `experiment-quicklinks` class, providing a neutral label for components tied to these tests.
 
 These artifacts can be cleaned up in the future if the builder functionality is fully deprecated.

--- a/layout/checkout.liquid
+++ b/layout/checkout.liquid
@@ -9,6 +9,13 @@
   
       <title>{{ page_title }}
       </title>
+      {% if settings.enable_experiments %}
+        {% comment %} Preload experiment assets when enabled {% endcomment %}
+        <link rel="preload" href="{{ 'scripts/experiments/experiments-utils.js' | asset_url }}" as="script">
+        <link rel="preload" href="{{ 'scripts/experiments/experiments-treatments.js' | asset_url }}" as="script">
+        <link rel="preload" href="{{ 'scripts/experiments/experiments-housefit.js' | asset_url }}" as="script">
+        <link rel="preload" href="{{ 'styles/experiments/experiments-treatments.css' | asset_url }}" as="style">
+      {% endif %}
       {% render 'experiment-assets' %}
     </head>
     <body>

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -33,12 +33,12 @@
       <link rel="preload" href="{{ 'algolia_dependency_font-awesome-4-4-0.min.css' | asset_url }}" as="style">
     {% endif %}
 
-    {% if settings.enable_proteus_experiments %}
-      {% comment %} Preload Proteus experiment assets when enabled {% endcomment %}
-      <link rel="preload" href="{{ 'scripts/experiments/proteus-utils.js' | asset_url }}" as="script">
-      <link rel="preload" href="{{ 'scripts/experiments/proteus-treatments.js' | asset_url }}" as="script">
-      <link rel="preload" href="{{ 'scripts/experiments/proteus-housefit.js' | asset_url }}" as="script">
-      <link rel="preload" href="{{ 'styles/proteus/proteus-treatments.css' | asset_url }}" as="style">
+    {% if settings.enable_experiments %}
+      {% comment %} Preload experiment assets when enabled {% endcomment %}
+      <link rel="preload" href="{{ 'scripts/experiments/experiments-utils.js' | asset_url }}" as="script">
+      <link rel="preload" href="{{ 'scripts/experiments/experiments-treatments.js' | asset_url }}" as="script">
+      <link rel="preload" href="{{ 'scripts/experiments/experiments-housefit.js' | asset_url }}" as="script">
+      <link rel="preload" href="{{ 'styles/experiments/experiments-treatments.css' | asset_url }}" as="style">
     {% endif %}
 
     <link rel="preload" href="{{ 'creative-judgement.css' | asset_url }}" as="style">

--- a/sections/main-collection.liquid
+++ b/sections/main-collection.liquid
@@ -53,7 +53,7 @@
 
 {% if quick_links.size > 0 %}
   <style>
-  /* Proteus experiment quicklinks */
+  /* Experiment quicklinks */
   .quicklinks_title {
     font-weight: 600;
     margin-bottom: 14px;

--- a/snippets/experiment-assets.liquid
+++ b/snippets/experiment-assets.liquid
@@ -1,9 +1,9 @@
-{% if settings.enable_proteus_experiments %}
-  {% comment %} Proteus experiment styles and scripts {% endcomment %}
-  {{ 'styles/proteus/proteus-treatments.css' | asset_url | stylesheet_tag }}
-  {{ 'scripts/experiments/proteus-utils.js' | asset_url | script_tag }}
-  {{ 'scripts/experiments/proteus-treatments.js' | asset_url | script_tag }}
-  {{ 'scripts/experiments/proteus-housefit.js' | asset_url | script_tag }}
+{% if settings.enable_experiments %}
+  {% comment %} Experiment styles and scripts {% endcomment %}
+  {{ 'styles/experiments/experiments-treatments.css' | asset_url | stylesheet_tag }}
+  {{ 'scripts/experiments/experiments-utils.js' | asset_url | script_tag }}
+  {{ 'scripts/experiments/experiments-treatments.js' | asset_url | script_tag }}
+  {{ 'scripts/experiments/experiments-housefit.js' | asset_url | script_tag }}
 {% endif %}
 {% if settings.enable_dtc_experiments %}
   {% comment %} DTC experiment assets {% endcomment %}

--- a/snippets/search-filter.liquid
+++ b/snippets/search-filter.liquid
@@ -160,7 +160,7 @@
 
       <div class="cc-product-filter cc-product-filter--sticky-{{ section.settings.sticky_sidebar }} {% if section.settings.sticky_sidebar %}cc-sticky-scroll-direction{% endif %}">
         {% if quick_links.size > 0 %}
-          <!-- Proteus experiment quicklinks -->
+          <!-- Experiment quicklinks -->
           <div class="experiment-quicklinks quicklinks-desktop">
           <div class="quicklinks_title">Product Quicklinks</div>
             {% for quick_link in quick_links %}


### PR DESCRIPTION
## Summary
- rename Proteus experiment assets and directories to neutral "experiments" names
- add matching preloads in theme and checkout layouts
- replace `enable_proteus_experiments` with `enable_experiments` and update docs/comments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6898a43a8fbc83329fb6ef6a600b464a