### PR TITLE
Refactor URL extraction for readability

### DIFF
--- a/snippets/header-content-app-filter.liquid
+++ b/snippets/header-content-app-filter.liquid
@@ -8,7 +8,14 @@
 {%- assign lines = content_for_header | newline_to_br | split: '<br />' -%}
 {%- for line in lines -%}
   {%- if line contains 'var urls' -%}
-    {% assign url_string = line | remove: 'var urls = [' | remove: '];' | strip %}
+    {% comment %}
+      Extract comma-separated URLs from JavaScript array declaration.
+    {% endcomment %}
+    {% assign url_string = line
+      | split: 'var urls = [' | last
+      | split: '];' | first
+      | strip
+    %}
     {% assign url_array = url_string | split: ',' | uniq %}
     {%- assign filtered_urls = '' -%}
     {%- for url in url_array -%}


### PR DESCRIPTION
## Summary
- break complex URL parsing line into multi-line chain with comments
- use split filters to remove JS variable wrappers, reducing repetition

## Testing
- `npm test`
- `node` sample verifying split-based logic matches original remove chain

------
https://chatgpt.com/codex/tasks/task_b_6898accde9188332ba7805e6bb92921a