### PR TITLE
Preload critical script in head

### DIFF
--- a/snippets/head-tag.liquid
+++ b/snippets/head-tag.liquid
@@ -37,8 +37,7 @@
   <link rel="preload" as="font" href="{{ logo_font | font_url }}" type="font/woff2" crossorigin>
 {%- endunless -%}
 
-<link rel="preload" href="{{ 'vendor.js' | asset_url }}" as="script">
-<link rel="preload" href="{{ 'theme.js' | asset_url }}" as="script">
+  <link rel="preload" href="{{ 'critical.js' | asset_url }}" as="script">
 
 {%- if canonical_url != blank  -%}
   <link rel="canonical" href="{{ canonical_url }}" />


### PR DESCRIPTION
## Summary
- preload `critical.js` instead of `vendor.js` and `theme.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6898c7b857bc833288449f911384a164