### PR TITLE
Remove duplicate Shopify CDN preconnect tag

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -50,12 +50,7 @@
 
     {% render 'replo-head' %}
     {% render 'revenueRoll-GTM' %}
-    <!-- Preconnect to Shopify CDN and Typekit -->
-    <link
-      rel="preconnect"
-      href="https://cdn.shopify.com"
-      crossorigin
-    >
+    <!-- Preconnect to Typekit -->
     <link
       rel="preconnect"
       href="https://use.typekit.net"


### PR DESCRIPTION
## Summary
- centralize Shopify CDN preconnect in `snippets/head-tag.liquid`
- update `layout/theme.liquid` to only preconnect to Typekit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6898c9f20f64833292deedd90babfbb8