### PR TITLE
Defer experiment assets and remove preload links

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -37,10 +37,10 @@
 
     {% if settings.enable_experiments %}
       <!-- Preload experiment assets -->
-      <link rel="preload" href="{{ 'scripts/experiments/experiments-utils.js' | asset_url }}" as="script">
-      <link rel="preload" href="{{ 'scripts/experiments/experiments-treatments.js' | asset_url }}" as="script">
-      <link rel="preload" href="{{ 'scripts/experiments/experiments-housefit.js' | asset_url }}" as="script">
-      <link rel="preload" href="{{ 'styles/experiments/experiments-treatments.css' | asset_url }}" as="style">
+      <!-- <link rel="preload" href="{{ 'scripts/experiments/experiments-utils.js' | asset_url }}" as="script"> -->
+      <!-- <link rel="preload" href="{{ 'scripts/experiments/experiments-treatments.js' | asset_url }}" as="script"> -->
+      <!-- <link rel="preload" href="{{ 'scripts/experiments/experiments-housefit.js' | asset_url }}" as="script"> -->
+      <!-- <link rel="preload" href="{{ 'styles/experiments/experiments-treatments.css' | asset_url }}" as="style"> -->
     {% endif %}
 
     <!-- Preload core theme styles -->
@@ -207,7 +207,6 @@
 
     {{ 'styles.css' | asset_url | stylesheet_tag }}
     {{ 'creative-judgement.css' | asset_url | stylesheet_tag }}
-    {% render 'experiment-assets' %}
     {%- capture content_for_header -%}
     {%- if tinyscript -%}
       {{ content_for_header }}
@@ -841,6 +840,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/js/select2.min.js" async></script>
 
     {% render 'body-end-tag' %}
+
+    {% render 'experiment-assets' %}
 
     {% comment %} Accessibe {% endcomment %}
     <script>

--- a/snippets/experiment-assets.liquid
+++ b/snippets/experiment-assets.liquid
@@ -1,12 +1,12 @@
 {% if settings.enable_experiments %}
   {% comment %} Experiment styles and scripts {% endcomment %}
   {{ 'styles/experiments/experiments-treatments.css' | asset_url | stylesheet_tag }}
-  {{ 'scripts/experiments/experiments-utils.js' | asset_url | script_tag }}
-  {{ 'scripts/experiments/experiments-treatments.js' | asset_url | script_tag }}
-  {{ 'scripts/experiments/experiments-housefit.js' | asset_url | script_tag }}
+  {{ 'scripts/experiments/experiments-utils.js' | asset_url | script_tag | replace: '<script', '<script defer' }}
+  {{ 'scripts/experiments/experiments-treatments.js' | asset_url | script_tag | replace: '<script', '<script defer' }}
+  {{ 'scripts/experiments/experiments-housefit.js' | asset_url | script_tag | replace: '<script', '<script defer' }}
 {% endif %}
 {% if settings.enable_dtc_experiments %}
   {% comment %} DTC experiment assets {% endcomment %}
   {{ 'styles/dtc/dtc-hero-slider.css' | asset_url | stylesheet_tag }}
-  {{ 'experiments/dtc/dtc-hero-slider.js' | asset_url | script_tag }}
+  {{ 'experiments/dtc/dtc-hero-slider.js' | asset_url | script_tag | replace: '<script', '<script defer' }}
 {% endif %}


### PR DESCRIPTION
## Summary
- remove preload links for experiment resources
- defer experiment scripts and load them after main content

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6898cb5dbdac833285cc7a77e578d187