### PR TITLE
Fix experiment tracking settings schema

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -847,22 +847,19 @@
     ]
   },
   {
-    "name": "Analytics and Experiments",
-
     "name": "Tracking",
-    "settings": [
-      {
-        "type": "checkbox",
-        "id": "enable_heatmap_tracking",
-        "label": "Enable Heatmap.com tracking",
-    "name": "Experiments",
     "settings": [
       {
         "type": "checkbox",
         "id": "enable_heatmap_tracking",
         "label": "Enable heatmap tracking",
         "default": false
-      },
+      }
+    ]
+  },
+  {
+    "name": "Experiments",
+    "settings": [
       {
         "type": "checkbox",
         "id": "enable_intelligems_tracking",
@@ -883,14 +880,6 @@
       },
       {
         "type": "checkbox",
-        "id": "enable_intelligems_tracking",
-        "label": "Enable Intelligems tracking",
-        "default": false
-      },
-      {
-        "type": "checkbox",
-        "id": "enable_ef_tracking",
-        "label": "Enable EF affiliate tracking",
         "id": "enable_dtc_experiments",
         "label": "Enable DTC experiments",
         "default": false


### PR DESCRIPTION
## Summary
- clean up tracking and experiment settings
- remove duplicate Intelligems and EF tracking entries

## Testing
- `npm test`
- `node - <<'NODE'
const fs = require('fs');
const theme = fs.readFileSync('layout/theme.liquid','utf8');
function render(enable){
  return theme.replace(/{% if settings.enable_intelligems_tracking %}([\s\S]*?){% endif %}/g, enable ? '$1' : '');
}
console.log('when enabled contains script?', render(true).includes('cdn.intelligems.io'));
console.log('when disabled contains script?', render(false).includes('cdn.intelligems.io'));
NODE`

------
https://chatgpt.com/codex/tasks/task_b_6898d29a8fcc8332b56a265193936a6d